### PR TITLE
Use a better file name date stamp format

### DIFF
--- a/main.c
+++ b/main.c
@@ -691,7 +691,7 @@ static AM_recordingState_t makeRecording(uint32_t currentTime, uint32_t recordDu
 
     struct tm *time = gmtime(&rawtime);
 
-    sprintf(fileName, "%04d%02d%02d_%02d%02d%02d.WAV", 1900 + time->tm_year, time->tm_mon + 1, time->tm_mday, time->tm_hour, time->tm_min, time->tm_sec);
+    sprintf(fileName, "%04d%02d%02dT%02d%02d%02dZ.WAV", 1900 + time->tm_year, time->tm_mon + 1, time->tm_mday, time->tm_hour, time->tm_min, time->tm_sec);
 
     RETURN_ON_ERROR(AudioMoth_openFile(fileName));
 


### PR DESCRIPTION
Thank you for adding support for long file names and sane and readable dates.

However, your new date format, I consider it to be a regression.

Your old date format was:
- unambiguous (it was a specialized encoding of UTC, easily matched with a regex)
- unreadable (it was an encoding)

Your new date format is:
- ambiguous (multiple other sensor platforms use the same format, it is not distinguishable from them, thus can now only be inferred as an ambiguous date time with respect to UTC)
- readable

My proposed date format:
- is unambiguous (the trailing 'Z' character is the standard notation for UTC/Zulu time)
- is readable (although for a beginner, slightly less so given the replacement of `_` with `T`
- follows the ISO8601 standard: https://en.wikipedia.org/wiki/ISO_8601

![Annotation 2019-09-11 114822](https://user-images.githubusercontent.com/1452968/64662198-dffd3700-d48a-11e9-9cdc-ec7c560e3bf1.png)

You make one of the few sensors on the market that has some notion of the real-time a recording occurred. Please don't obscure this information. I'm confident there's a balance between readability for novices and interpretability for programs. 

I'm aware you also encode unique information in the headers. In my opinion, if I have to read bytes in a file header to understand a datestamp then the problem is already too hard - especially for a novice who is parsing a date in R.

Lastly, I don't use C. I have no idea if this patch will work but according to by basic research, that format string should be sufficient.